### PR TITLE
Global Security.md and issue template

### DIFF
--- a/ISSUE_TEMPLATE/bug_report.md
+++ b/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Report an issue
+about: Create a report about an issue you found in the Mattermost
+---
+
+Per Mattermost guidelines, GitHub issues are for bug reports:
+<https://handbook.mattermost.com/contributors/contributors/ways-to-contribute/>.
+
+For troubleshooting see: https://forum.mattermost.com/.  For feature proposals
+see: https://mattermost.com/suggestions/
+
+If you've found a bug--something appears unintentional--please follow these
+steps:
+
+1. Confirm you’re filing a new issue. [Search existing tickets in
+   Jira](https://mattermost.atlassian.net/jira/software/c/projects/MM/issues/)
+   to ensure that the ticket does not already exist.
+2. Confirm your issue does not involve security. Otherwise, please see our
+   [Responsible Disclosure
+   Policy](https://mattermost.com/security-vulnerability-report/).
+3. [File a new issue](https://github.com/mattermost/mattermost/issues/new)
+   using the format below. Mattermost will confirm steps to reproduce and file
+   in Jira, or ask for more details if there is trouble reproducing it. If
+   there's already an existing bug in Jira, it will be linked back to the
+   GitHub issue so you can track when it gets fixed.
+
+#### Summary
+Bug report in one concise sentence
+
+#### Steps to reproduce
+How can we reproduce the issue (what version are you
+using?)
+
+#### Expected behavior
+Describe your issue in detail
+
+#### Observed behavior (that appears unintentional)
+What did you see happen? Please include relevant error messages and/or screenshots.
+
+#### Possible fixes
+If you can, link to the line of code that might be responsible for the problem

--- a/ISSUE_TEMPLATE/config.yml
+++ b/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+Security
+========
+
+Safety and data security is of the utmost priority for the Mattermost community. If you are a security researcher and have discovered a security vulnerability in our codebase, we would appreciate your help in disclosing it to us in a responsible manner.
+
+Reporting security issues
+-------------------------
+
+**Please do not use GitHub issues for security-sensitive communication.**
+
+Security issues in the community test server, any of the open source codebases maintained by Mattermost, or any of our commercial offerings should be reported via email to [responsibledisclosure@mattermost.com](mailto:responsibledisclosure@mattermost.com). Mattermost is committed to working together with researchers and keeping them updated throughout the patching process. Researchers who responsibly report valid security issues will be publicly credited for their efforts (if they so choose).
+
+For a more detailed description of the disclosure process and a list of researchers who have previously contributed to the disclosure program, see [Report a Security Vulnerability](https://mattermost.com/security-vulnerability-report/) on the Mattermost website.
+
+Security updates
+----------------
+
+Mattermost has a mandatory upgrade policy, and updates are only provided for the latest 3 releases and the current Extended Support Release (ESR). Critical updates are delivered as dot releases. Details on security updates are announced 30 days after the availability of the update.
+
+For more details about the security content of past releases, see the [Security Updates](https://mattermost.com/security-updates/) page on the Mattermost website. For timely notifications about new security updates, subscribe to the [Security Bulletins Mailing List](https://mattermost.com/security-updates/#sign-up).
+
+Contributing to this policy
+---------------------------
+
+If you have feedback or suggestions on improving this policy document, please [create an issue](https://github.com/mattermost/.github/issues/new).


### PR DESCRIPTION
#### Summary
Adds a SECURITY.md globally so that it's visible in all repositories under the Mattermost org. It also creates a global bug report template.  

After merging this, every time someone will attempt to create a new issue, they'll be presented to choose between a Bug report and reading the Security policy for submitting a vulnerability. 

Both files were copied from the https://github.com/mattermost/mattermost repo
